### PR TITLE
Use C99 to compile libmultihash.so

### DIFF
--- a/src/Native/libmultihash/Makefile
+++ b/src/Native/libmultihash/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -c -fPIC -O2 -g -Wno-pointer-sign -Wno-unused-function -Wno-strict-aliasing -Wno-discarded-qualifiers
+CFLAGS = -std=c99 -Wall -c -fPIC -O2 -g -Wno-pointer-sign -Wno-unused-function -Wno-strict-aliasing -Wno-discarded-qualifiers
 CXXFLAGS = -Wall -fPIC -fpermissive -O2 -g -Wno-unused-function -Wno-strict-aliasing
 LDFLAGS = -shared
 LDLIBS = -lsodium


### PR DESCRIPTION
Add flag -std=c99 to CFLAGS, otherwise build breaks on for loops where variable needs to be declared outside scope.